### PR TITLE
adds support for empty dart classes

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Updates minimum supported SDK version to Flutter 3.27/Dart 3.6.
 
+## 25.3.3
+
+* Adds support for empty data classes.
+
 ## 25.3.2
 
 * [dart] Fixes null pointer crashes/exceptions caused by premature finalization of Dart instances

--- a/packages/pigeon/example/README.md
+++ b/packages/pigeon/example/README.md
@@ -390,6 +390,8 @@ Stream<String> getEventStream() async* {
       case StringEvent():
         final String stringData = event.data;
         yield '$stringData, ';
+      case EmptyEvent():
+        yield '';
     }
   }
 }
@@ -417,6 +419,12 @@ class EventListener: StreamEventsStreamHandler {
   func onStringEvent(event: String) {
     if let eventSink = eventSink {
       eventSink.success(StringEvent(data: event))
+    }
+  }
+
+  func onEmptyEvent() {
+    if let eventSink = eventSink {
+      eventSink.success(EmptyEvent())
     }
   }
 
@@ -455,6 +463,10 @@ class EventListener : StreamEventsStreamHandler() {
 
   fun onStringEvent(event: String) {
     eventSink?.success(StringEvent(data = event))
+  }
+
+  fun onEmptyEvent() {
+    eventSink?.success(EmptyEvent())
   }
 
   fun onEventsDone() {

--- a/packages/pigeon/example/app/android/app/src/main/kotlin/dev/flutter/pigeon_example_app/EventChannelMessages.g.kt
+++ b/packages/pigeon/example/app/android/app/src/main/kotlin/dev/flutter/pigeon_example_app/EventChannelMessages.g.kt
@@ -101,6 +101,32 @@ data class StringEvent(val data: String) : PlatformEvent() {
   override fun hashCode(): Int = toList().hashCode()
 }
 
+/** Generated class from Pigeon that represents data sent in messages. */
+class EmptyEvent() : PlatformEvent() {
+  companion object {
+    @Suppress("UNUSED_PARAMETER")
+    fun fromList(pigeonVar_list: List<Any?>): EmptyEvent {
+      return EmptyEvent()
+    }
+  }
+
+  fun toList(): List<Any?> {
+    return listOf()
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (other !is EmptyEvent) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return EventChannelMessagesPigeonUtils.deepEquals(toList(), other.toList())
+  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
+
 private open class EventChannelMessagesPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
@@ -109,6 +135,9 @@ private open class EventChannelMessagesPigeonCodec : StandardMessageCodec() {
       }
       130.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let { StringEvent.fromList(it) }
+      }
+      131.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let { EmptyEvent.fromList(it) }
       }
       else -> super.readValueOfType(type, buffer)
     }
@@ -122,6 +151,10 @@ private open class EventChannelMessagesPigeonCodec : StandardMessageCodec() {
       }
       is StringEvent -> {
         stream.write(130)
+        writeValue(stream, value.toList())
+      }
+      is EmptyEvent -> {
+        stream.write(131)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/packages/pigeon/example/app/android/app/src/main/kotlin/dev/flutter/pigeon_example_app/MainActivity.kt
+++ b/packages/pigeon/example/app/android/app/src/main/kotlin/dev/flutter/pigeon_example_app/MainActivity.kt
@@ -4,6 +4,7 @@
 
 package dev.flutter.pigeon_example_app
 
+import EmptyEvent
 import ExampleHostApi
 import FlutterError
 import IntEvent
@@ -72,6 +73,10 @@ class EventListener : StreamEventsStreamHandler() {
     eventSink?.success(StringEvent(data = event))
   }
 
+  fun onEmptyEvent() {
+    eventSink?.success(EmptyEvent())
+  }
+
   fun onEventsDone() {
     eventSink?.endOfStream()
     eventSink = null
@@ -91,6 +96,11 @@ fun sendEvents(eventListener: EventListener) {
             if (count % 2 == 0) {
               handler.post {
                 eventListener.onIntEvent(count.toLong())
+                count++
+              }
+            } else if (count % 5 == 0) {
+              handler.post {
+                eventListener.onEmptyEvent()
                 count++
               }
             } else {

--- a/packages/pigeon/example/app/ios/Runner/AppDelegate.swift
+++ b/packages/pigeon/example/app/ios/Runner/AppDelegate.swift
@@ -66,6 +66,12 @@ class EventListener: StreamEventsStreamHandler {
     }
   }
 
+  func onEmptyEvent() {
+    if let eventSink = eventSink {
+      eventSink.success(EmptyEvent())
+    }
+  }
+
   func onEventsDone() {
     eventSink?.endOfStream()
     eventSink = nil
@@ -84,6 +90,8 @@ func sendEvents(_ eventListener: EventListener) {
       } else {
         if (count % 2) == 0 {
           eventListener.onIntEvent(event: Int64(count))
+        } else if (count % 5) == 0 {
+          eventListener.onEmptyEvent()
         } else {
           eventListener.onStringEvent(event: String(count))
         }

--- a/packages/pigeon/example/app/ios/Runner/EventChannelMessages.g.swift
+++ b/packages/pigeon/example/app/ios/Runner/EventChannelMessages.g.swift
@@ -141,6 +141,25 @@ struct StringEvent: PlatformEvent {
   }
 }
 
+/// Generated class from Pigeon that represents data sent in messages.
+struct EmptyEvent: PlatformEvent {
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> EmptyEvent? {
+
+    return EmptyEvent()
+  }
+  func toList() -> [Any?] {
+    return []
+  }
+  static func == (lhs: EmptyEvent, rhs: EmptyEvent) -> Bool {
+    return deepEqualsEventChannelMessages(lhs.toList(), rhs.toList())
+  }
+  func hash(into hasher: inout Hasher) {
+    deepHashEventChannelMessages(value: toList(), hasher: &hasher)
+  }
+}
+
 private class EventChannelMessagesPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
@@ -148,6 +167,8 @@ private class EventChannelMessagesPigeonCodecReader: FlutterStandardReader {
       return IntEvent.fromList(self.readValue() as! [Any?])
     case 130:
       return StringEvent.fromList(self.readValue() as! [Any?])
+    case 131:
+      return EmptyEvent.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -161,6 +182,9 @@ private class EventChannelMessagesPigeonCodecWriter: FlutterStandardWriter {
       super.writeValue(value.toList())
     } else if let value = value as? StringEvent {
       super.writeByte(130)
+      super.writeValue(value.toList())
+    } else if let value = value as? EmptyEvent {
+      super.writeByte(131)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/packages/pigeon/example/app/lib/main.dart
+++ b/packages/pigeon/example/app/lib/main.dart
@@ -99,6 +99,8 @@ class _MyHomePageState extends State<MyHomePage> {
         case StringEvent():
           final String stringData = event.data;
           yield '$stringData, ';
+        case EmptyEvent():
+          yield '';
       }
     }
   }

--- a/packages/pigeon/example/app/lib/src/event_channel_messages.g.dart
+++ b/packages/pigeon/example/app/lib/src/event_channel_messages.g.dart
@@ -110,6 +110,37 @@ class StringEvent extends PlatformEvent {
   int get hashCode => Object.hashAll(_toList());
 }
 
+class EmptyEvent extends PlatformEvent {
+  List<Object?> _toList() {
+    return <Object?>[];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static EmptyEvent decode(Object result) {
+    result as List<Object?>;
+    return EmptyEvent();
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! EmptyEvent || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -123,6 +154,9 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is StringEvent) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
+    } else if (value is EmptyEvent) {
+      buffer.putUint8(131);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -135,6 +169,8 @@ class _PigeonCodec extends StandardMessageCodec {
         return IntEvent.decode(readValue(buffer)!);
       case 130:
         return StringEvent.decode(readValue(buffer)!);
+      case 131:
+        return EmptyEvent.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/pigeon/example/app/lib/src/event_channel_messages.g.dart
+++ b/packages/pigeon/example/app/lib/src/event_channel_messages.g.dart
@@ -119,8 +119,7 @@ class EmptyEvent extends PlatformEvent {
     return _toList();
   }
 
-  static EmptyEvent decode(Object result) {
-    result as List<Object?>;
+  static EmptyEvent decode(Object _) {
     return EmptyEvent();
   }
 

--- a/packages/pigeon/example/app/pigeons/event_channel_messages.dart
+++ b/packages/pigeon/example/app/pigeons/event_channel_messages.dart
@@ -33,6 +33,9 @@ class StringEvent extends PlatformEvent {
   StringEvent(this.data);
   String data;
 }
+
+class EmptyEvent extends PlatformEvent {}
+
 // #enddocregion sealed-definitions
 
 // #docregion event-definitions

--- a/packages/pigeon/lib/src/dart/dart_generator.dart
+++ b/packages/pigeon/lib/src/dart/dart_generator.dart
@@ -200,19 +200,22 @@ class DartGenerator extends StructuredGenerator<InternalDartOptions> {
 
     indent.write('${sealed}class ${classDefinition.name} $implements');
     indent.addScoped('{', '}', () {
-      if (classDefinition.fields.isEmpty) {
+      if (classDefinition.isSealed) {
         return;
       }
-      _writeConstructor(indent, classDefinition);
-      indent.newln();
-      for (final NamedType field
-          in getFieldsInSerializationOrder(classDefinition)) {
-        addDocumentationComments(
-            indent, field.documentationComments, _docCommentSpec);
 
-        final String datatype = _addGenericTypesNullable(field.type);
-        indent.writeln('$datatype ${field.name};');
+      if (classDefinition.fields.isNotEmpty) {
+        _writeConstructor(indent, classDefinition);
         indent.newln();
+        for (final NamedType field
+            in getFieldsInSerializationOrder(classDefinition)) {
+          addDocumentationComments(
+              indent, field.documentationComments, _docCommentSpec);
+
+          final String datatype = _addGenericTypesNullable(field.type);
+          indent.writeln('$datatype ${field.name};');
+          indent.newln();
+        }
       }
       _writeToList(indent, classDefinition);
       indent.newln();

--- a/packages/pigeon/lib/src/dart/dart_generator.dart
+++ b/packages/pigeon/lib/src/dart/dart_generator.dart
@@ -318,11 +318,16 @@ class DartGenerator extends StructuredGenerator<InternalDartOptions> {
       }
     }
 
+    final bool isResultUsed = classDefinition.fields.isNotEmpty;
+    final String result = isResultUsed ? 'result' : '_';
+
     indent.write(
-      'static ${classDefinition.name} decode(Object result) ',
+      'static ${classDefinition.name} decode(Object $result) ',
     );
     indent.addScoped('{', '}', () {
-      indent.writeln('result as List<Object?>;');
+      if (isResultUsed) {
+        indent.writeln('result as List<Object?>;');
+      }
       indent.write('return ${classDefinition.name}');
       indent.addScoped('(', ');', () {
         enumerate(getFieldsInSerializationOrder(classDefinition),

--- a/packages/pigeon/lib/src/generator_tools.dart
+++ b/packages/pigeon/lib/src/generator_tools.dart
@@ -15,7 +15,7 @@ import 'generator.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '25.3.2';
+const String pigeonVersion = '25.3.3';
 
 /// Read all the content from [stdin] to a String.
 String readStdin() {

--- a/packages/pigeon/lib/src/kotlin/kotlin_generator.dart
+++ b/packages/pigeon/lib/src/kotlin/kotlin_generator.dart
@@ -330,7 +330,11 @@ class KotlinGenerator extends StructuredGenerator<InternalKotlinOptions> {
     bool private = false,
   }) {
     final String privateString = private ? 'private ' : '';
-    final String classType = classDefinition.isSealed ? 'sealed' : 'data';
+    final String classType = classDefinition.isSealed
+        ? 'sealed'
+        : classDefinition.fields.isNotEmpty
+            ? 'data'
+            : '';
     final String inheritance = classDefinition.superClass != null
         ? ' : ${classDefinition.superClassName}()'
         : '';
@@ -384,6 +388,10 @@ class KotlinGenerator extends StructuredGenerator<InternalKotlinOptions> {
 
     indent.write('companion object ');
     indent.addScoped('{', '}', () {
+      if (getFieldsInSerializationOrder(classDefinition).isEmpty) {
+        indent.writeln('@Suppress("UNUSED_PARAMETER")');
+      }
+
       indent
           .write('fun fromList(${varNamePrefix}list: List<Any?>): $className ');
 

--- a/packages/pigeon/pigeons/event_channel_tests.dart
+++ b/packages/pigeon/pigeons/event_channel_tests.dart
@@ -1,6 +1,8 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+//
+//! Exists because of the sealed classes and event channels are not supported for C++ and GObjects.
 
 import 'package:pigeon/pigeon.dart';
 
@@ -137,9 +139,16 @@ class ClassEvent extends PlatformEvent {
   final EventAllNullableTypes value;
 }
 
+class EmptyEvent extends PlatformEvent {}
+
 @EventChannelApi()
 abstract class EventChannelMethods {
   int streamInts();
   PlatformEvent streamEvents();
   int streamConsistentNumbers();
+}
+
+@HostApi()
+abstract class SealedClassApi {
+  PlatformEvent echo(PlatformEvent event);
 }

--- a/packages/pigeon/platform_tests/alternate_language_test_plugin/example/integration_test/test.dart
+++ b/packages/pigeon/platform_tests/alternate_language_test_plugin/example/integration_test/test.dart
@@ -13,7 +13,7 @@ TargetGenerator _getTarget() {
     return TargetGenerator.java;
   }
   if (Platform.isIOS || Platform.isMacOS) {
-    return TargetGenerator.objc;
+    return TargetGenerator.swift;
   }
   throw UnimplementedError('Unsupported target.');
 }

--- a/packages/pigeon/platform_tests/shared_test_plugin_code/lib/event_test_types.dart
+++ b/packages/pigeon/platform_tests/shared_test_plugin_code/lib/event_test_types.dart
@@ -1,0 +1,98 @@
+import 'generated.dart';
+import 'test_types.dart';
+
+// ignore_for_file: public_member_api_docs
+
+final Map<int, EventAllNullableTypes?> eventAllNullableTypesMap =
+    <int, EventAllNullableTypes?>{
+  0: genericEventAllNullableTypesWithoutRecursion,
+  1: EventAllNullableTypes(),
+  2: null,
+};
+
+final Map<EventEnum?, EventEnum?> eventEnumMap = <EventEnum, EventEnum>{
+  EventEnum.one: EventEnum.one,
+  EventEnum.two: EventEnum.two,
+  EventEnum.three: EventEnum.three,
+  EventEnum.fortyTwo: EventEnum.fortyTwo,
+};
+
+final List<EventEnum?> eventEnumList = <EventEnum>[
+  EventEnum.one,
+  EventEnum.two,
+  EventEnum.three,
+  EventEnum.fortyTwo,
+];
+
+final List<List<Object?>?> eventListList = <List<Object?>?>[
+  list,
+  stringList,
+  intList,
+  doubleList,
+  boolList,
+  eventEnumList,
+  null
+];
+
+final List<Map<Object?, Object?>?> eventMapList = <Map<Object?, Object?>?>[
+  map,
+  stringMap,
+  doubleMap,
+  intMap,
+  boolMap,
+  eventEnumMap,
+  null
+];
+
+final Map<int?, List<Object?>?> eventListMap = <int?, List<Object?>?>{
+  0: list,
+  1: stringList,
+  2: doubleList,
+  4: intList,
+  5: boolList,
+  6: eventEnumList,
+  7: null
+};
+
+final Map<int?, Map<Object?, Object?>?> eventMapMap =
+    <int?, Map<Object?, Object?>?>{
+  0: map,
+  1: stringMap,
+  2: doubleMap,
+  4: intMap,
+  5: boolMap,
+  6: eventEnumMap,
+  7: null
+};
+
+final EventAllNullableTypes genericEventAllNullableTypesWithoutRecursion =
+    EventAllNullableTypes(
+  aNullableBool: true,
+  aNullableInt: regularInt,
+  aNullableInt64: biggerThanBigInt,
+  aNullableDouble: doublePi,
+  aNullableByteArray: genericAllNullableTypes.aNullableByteArray,
+  aNullable4ByteArray: genericAllNullableTypes.aNullable4ByteArray,
+  aNullable8ByteArray: genericAllNullableTypes.aNullable8ByteArray,
+  aNullableFloatArray: genericAllNullableTypes.aNullableFloatArray,
+  aNullableEnum: EventEnum.fortyTwo,
+  anotherNullableEnum: AnotherEventEnum.justInCase,
+  aNullableString: genericAllNullableTypes.aNullableString,
+  aNullableObject: genericAllNullableTypes.aNullableObject,
+  list: list,
+  stringList: stringList,
+  intList: intList,
+  doubleList: doubleList,
+  boolList: boolList,
+  enumList: eventEnumList,
+  objectList: list,
+  listList: eventListList,
+  mapList: eventMapList,
+  map: map,
+  stringMap: stringMap,
+  intMap: intMap,
+  enumMap: eventEnumMap,
+  objectMap: map,
+  listMap: eventListMap,
+  mapMap: eventMapMap,
+);

--- a/packages/pigeon/platform_tests/shared_test_plugin_code/lib/integration_tests.dart
+++ b/packages/pigeon/platform_tests/shared_test_plugin_code/lib/integration_tests.dart
@@ -11,6 +11,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'event_test_types.dart';
 import 'generated.dart';
 import 'test_types.dart';
 
@@ -2934,6 +2935,9 @@ void runPigeonIntegrationTests(TargetGenerator targetGenerator) {
           expect(event.value.aNullableInt, 0);
           expect(count, 6);
           count++;
+        case EmptyEvent():
+          expect(count, 7);
+          count++;
           completer.complete();
       }
     });
@@ -2957,6 +2961,158 @@ void runPigeonIntegrationTests(TargetGenerator targetGenerator) {
     await completer1.future;
     await completer2.future;
   }, skip: !eventChannelSupported.contains(targetGenerator));
+
+  testWidgets(
+    'sealed subclass IntEvent with Int and deserialize correctly',
+    (WidgetTester _) async {
+      final SealedClassApi api = SealedClassApi();
+
+      const int sentInt = regularInt;
+      final PlatformEvent receivedEvent =
+          await api.echo(IntEvent(value: sentInt));
+      switch (receivedEvent) {
+        case IntEvent():
+          expect(receivedEvent.value, sentInt);
+        default:
+          fail('Received unexpected event: $receivedEvent');
+      }
+    },
+  );
+
+  testWidgets(
+    'sealed subclass IntEvent with Int64 serialize and deserialize correctly',
+    (WidgetTester _) async {
+      final SealedClassApi api = SealedClassApi();
+
+      const int sentInt = biggerThanBigInt;
+      final PlatformEvent receivedEvent =
+          await api.echo(IntEvent(value: sentInt));
+      switch (receivedEvent) {
+        case IntEvent():
+          expect(receivedEvent.value, sentInt);
+        default:
+          fail('Received unexpected event: $receivedEvent');
+      }
+    },
+  );
+
+  testWidgets(
+    'sealed subclass DoubleEvent serialize and deserialize correctly',
+    (WidgetTester _) async {
+      final SealedClassApi api = SealedClassApi();
+
+      const double sentDouble = 2.0694;
+      final PlatformEvent receivedEvent =
+          await api.echo(DoubleEvent(value: sentDouble));
+      switch (receivedEvent) {
+        case DoubleEvent():
+          expect(receivedEvent.value, sentDouble);
+        default:
+          fail('Received unexpected event: $receivedEvent');
+      }
+    },
+  );
+
+  testWidgets(
+    'sealed subclass BooleanEvent serialize and deserialize correctly',
+    (WidgetTester _) async {
+      final SealedClassApi api = SealedClassApi();
+
+      for (final bool sentBool in <bool>[true, false]) {
+        final PlatformEvent receivedEvent =
+            await api.echo(BoolEvent(value: sentBool));
+        switch (receivedEvent) {
+          case BoolEvent():
+            expect(receivedEvent.value, sentBool);
+          default:
+            fail('Received unexpected event: $receivedEvent');
+        }
+      }
+    },
+  );
+
+  testWidgets(
+    'sealed subclass StringEvent serialize and deserialize correctly',
+    (WidgetTester _) async {
+      final SealedClassApi api = SealedClassApi();
+
+      const String sentString = 'default';
+      final PlatformEvent receivedEvent =
+          await api.echo(StringEvent(value: sentString));
+      switch (receivedEvent) {
+        case StringEvent():
+          expect(receivedEvent.value, sentString);
+        default:
+          fail('Received unexpected event: $receivedEvent');
+      }
+    },
+  );
+
+  testWidgets(
+    'sealed subclass ObjectsEvent serialize and deserialize correctly',
+    (WidgetTester _) async {
+      final SealedClassApi api = SealedClassApi();
+
+      const Object sentObject = true;
+      final PlatformEvent receivedEvent =
+          await api.echo(ObjectsEvent(value: sentObject));
+      switch (receivedEvent) {
+        case ObjectsEvent():
+          expect(receivedEvent.value, sentObject);
+        default:
+          fail('Received unexpected event: $receivedEvent');
+      }
+    },
+  );
+
+  testWidgets(
+    'sealed subclass EnumEvent serialize and deserialize correctly',
+    (WidgetTester _) async {
+      final SealedClassApi api = SealedClassApi();
+
+      const EventEnum sentEnum = EventEnum.fortyTwo;
+      final PlatformEvent receivedEvent =
+          await api.echo(EnumEvent(value: sentEnum));
+      switch (receivedEvent) {
+        case EnumEvent():
+          expect(receivedEvent.value, sentEnum);
+        default:
+          fail('Received unexpected event: $receivedEvent');
+      }
+    },
+  );
+
+  testWidgets(
+    'sealed subclass ClassEvent serialize and deserialize correctly',
+    (WidgetTester _) async {
+      final SealedClassApi api = SealedClassApi();
+      final EventAllNullableTypes sentEventAllNullableTypes =
+          genericEventAllNullableTypesWithoutRecursion;
+      final PlatformEvent receivedEvent = await api.echo(
+        ClassEvent(value: sentEventAllNullableTypes),
+      );
+
+      switch (receivedEvent) {
+        case ClassEvent():
+          expect(
+            receivedEvent.value,
+            sentEventAllNullableTypes,
+          );
+        default:
+          fail('Received unexpected event: $receivedEvent');
+      }
+    },
+  );
+
+  testWidgets(
+    'sealed Empty subclass serialize and deserialize correctly',
+    (WidgetTester _) async {
+      final SealedClassApi api = SealedClassApi();
+
+      final PlatformEvent receivedEvent = await api.echo(EmptyEvent());
+      expect(receivedEvent, isA<EmptyEvent>());
+    },
+  );
 }
 
 class _FlutterApiTestImplementation implements FlutterIntegrationCoreApi {

--- a/packages/pigeon/platform_tests/shared_test_plugin_code/lib/src/generated/event_channel_tests.gen.dart
+++ b/packages/pigeon/platform_tests/shared_test_plugin_code/lib/src/generated/event_channel_tests.gen.dart
@@ -543,8 +543,7 @@ class EmptyEvent extends PlatformEvent {
     return _toList();
   }
 
-  static EmptyEvent decode(Object result) {
-    result as List<Object?>;
+  static EmptyEvent decode(Object _) {
     return EmptyEvent();
   }
 

--- a/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/TestPlugin.kt
+++ b/packages/pigeon/platform_tests/test_plugin/android/src/main/kotlin/com/example/test_plugin/TestPlugin.kt
@@ -10,7 +10,7 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
 
 /** This plugin handles the native side of the integration tests in example/integration_test/. */
-class TestPlugin : FlutterPlugin, HostIntegrationCoreApi {
+class TestPlugin : FlutterPlugin, HostIntegrationCoreApi, SealedClassApi {
   private var flutterApi: FlutterIntegrationCoreApi? = null
   private var flutterSmallApiOne: FlutterSmallApi? = null
   private var flutterSmallApiTwo: FlutterSmallApi? = null
@@ -35,6 +35,7 @@ class TestPlugin : FlutterPlugin, HostIntegrationCoreApi {
         binding.binaryMessenger, SendConsistentNumbers(1), "1")
     StreamConsistentNumbersStreamHandler.register(
         binding.binaryMessenger, SendConsistentNumbers(2), "2")
+    SealedClassApi.setUp(binding.binaryMessenger, this)
   }
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
@@ -868,6 +869,8 @@ class TestPlugin : FlutterPlugin, HostIntegrationCoreApi {
   fun testUnusedClassesGenerate(): UnusedClass {
     return UnusedClass()
   }
+
+  override fun echo(event: PlatformEvent): PlatformEvent = event
 }
 
 class TestPluginWithSuffix : HostSmallApi {
@@ -918,7 +921,8 @@ object SendClass : StreamEventsStreamHandler() {
           DoubleEvent(3.14),
           ObjectsEvent(true),
           EnumEvent(EventEnum.FORTY_TWO),
-          ClassEvent(EventAllNullableTypes(aNullableInt = 0)))
+          ClassEvent(EventAllNullableTypes(aNullableInt = 0)),
+          EmptyEvent())
 
   override fun onListen(p0: Any?, sink: PigeonEventSink<PlatformEvent>) {
     var count: Int = 0

--- a/packages/pigeon/platform_tests/test_plugin/darwin/test_plugin/Sources/test_plugin/TestPlugin.swift
+++ b/packages/pigeon/platform_tests/test_plugin/darwin/test_plugin/Sources/test_plugin/TestPlugin.swift
@@ -12,7 +12,7 @@ import Foundation
 
 /// This plugin handles the native side of the integration tests in
 /// example/integration_test/.
-public class TestPlugin: NSObject, FlutterPlugin, HostIntegrationCoreApi {
+public class TestPlugin: NSObject, FlutterPlugin, HostIntegrationCoreApi, SealedClassApi {
   var flutterAPI: FlutterIntegrationCoreApi
   var flutterSmallApiOne: FlutterSmallApi
   var flutterSmallApiTwo: FlutterSmallApi
@@ -29,6 +29,7 @@ public class TestPlugin: NSObject, FlutterPlugin, HostIntegrationCoreApi {
     HostIntegrationCoreApiSetup.setUp(binaryMessenger: messenger, api: plugin)
     TestPluginWithSuffix.register(with: registrar, suffix: "suffixOne")
     TestPluginWithSuffix.register(with: registrar, suffix: "suffixTwo")
+    SealedClassApiSetup.setUp(binaryMessenger: registrar.messenger(), api: plugin)
     registrar.publish(plugin)
   }
 
@@ -1222,6 +1223,8 @@ public class TestPlugin: NSObject, FlutterPlugin, HostIntegrationCoreApi {
   func testUnusedClassesGenerate() -> UnusedClass {
     return UnusedClass()
   }
+
+  func echo(event: any PlatformEvent) throws -> any PlatformEvent { event }
 }
 
 public class TestPluginWithSuffix: HostSmallApi {
@@ -1281,6 +1284,7 @@ class SendEvents: StreamEventsStreamHandler {
       ObjectsEvent(value: true),
       EnumEvent(value: EventEnum.fortyTwo),
       ClassEvent(value: EventAllNullableTypes(aNullableInt: 0)),
+      EmptyEvent(),
     ]
 
   override func onListen(withArguments arguments: Any?, sink: PigeonEventSink<PlatformEvent>) {

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pigeon%22
-version: 25.3.2 # This must match the version in lib/src/generator_tools.dart
+version: 25.3.3 # This must match the version in lib/src/generator_tools.dart
 
 environment:
   sdk: ^3.6.0

--- a/packages/pigeon/test/dart_generator_test.dart
+++ b/packages/pigeon/test/dart_generator_test.dart
@@ -1820,4 +1820,102 @@ name: foobar
     expect(code, contains('buffer.putUint8(4);'));
     expect(code, contains('buffer.putInt64(value);'));
   });
+
+  test('sealed class', () {
+    final Class superClass = Class(
+      name: 'PlatformEvent',
+      isSealed: true,
+      fields: const <NamedType>[],
+    );
+    final Root root = Root(
+      apis: <Api>[],
+      classes: <Class>[
+        superClass,
+        Class(
+          name: 'IntEvent',
+          superClass: superClass,
+          superClassName: superClass.name,
+          fields: <NamedType>[
+            NamedType(
+              type: const TypeDeclaration(
+                baseName: 'int',
+                isNullable: false,
+              ),
+              name: 'value',
+            )
+          ],
+        ),
+        Class(
+          name: 'ClassEvent',
+          superClass: superClass,
+          superClassName: superClass.name,
+          fields: <NamedType>[
+            NamedType(
+              type: TypeDeclaration(
+                baseName: 'Input',
+                isNullable: true,
+                associatedClass: emptyClass,
+              ),
+              name: 'value',
+            )
+          ],
+        ),
+      ],
+      enums: <Enum>[],
+    );
+    final StringBuffer sink = StringBuffer();
+    const DartGenerator generator = DartGenerator();
+    generator.generate(
+      const InternalDartOptions(),
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+    expect(
+      code,
+      contains('sealed class PlatformEvent'),
+    );
+    expect(
+      code,
+      contains('class IntEvent extends PlatformEvent'),
+    );
+    expect(
+      code,
+      contains('class ClassEvent extends PlatformEvent'),
+    );
+    expect(
+      code,
+      contains('result[0]! as int'),
+    );
+    expect(
+      code,
+      contains('result[0] as Input?'),
+    );
+  });
+
+  test('empty class', () {
+    final Root root = Root(
+      apis: <Api>[],
+      classes: <Class>[
+        Class(
+          name: 'EmptyClass',
+          fields: <NamedType>[],
+        ),
+      ],
+      enums: <Enum>[],
+    );
+    final StringBuffer sink = StringBuffer();
+    const DartGenerator generator = DartGenerator();
+    generator.generate(
+      const InternalDartOptions(),
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+
+    expect(code, contains('static EmptyClass decode(Object _)'));
+    expect(code, isNot(contains('result as List<Object?>')));
+  });
 }

--- a/packages/pigeon/test/kotlin_generator_test.dart
+++ b/packages/pigeon/test/kotlin_generator_test.dart
@@ -1892,4 +1892,99 @@ void main() {
     // There should be only one occurrence of 'is Foo' in the block
     expect(count, 1);
   });
+
+  test('sealed class', () {
+    final Class superClass = Class(
+      name: 'PlatformEvent',
+      isSealed: true,
+      fields: const <NamedType>[],
+    );
+    final Root root = Root(
+      apis: <Api>[],
+      classes: <Class>[
+        superClass,
+        Class(
+          name: 'IntEvent',
+          superClass: superClass,
+          superClassName: superClass.name,
+          fields: <NamedType>[
+            NamedType(
+              type: const TypeDeclaration(
+                baseName: 'int',
+                isNullable: false,
+              ),
+              name: 'value',
+            )
+          ],
+        ),
+        Class(
+          name: 'ClassEvent',
+          superClass: superClass,
+          superClassName: superClass.name,
+          fields: <NamedType>[
+            NamedType(
+              type: TypeDeclaration(
+                baseName: 'Input',
+                isNullable: true,
+                associatedClass: emptyClass,
+              ),
+              name: 'value',
+            )
+          ],
+        ),
+      ],
+      enums: <Enum>[],
+    );
+    final StringBuffer sink = StringBuffer();
+    const KotlinGenerator generator = KotlinGenerator();
+    const InternalKotlinOptions kotlinOptions =
+        InternalKotlinOptions(kotlinOut: '');
+    generator.generate(
+      kotlinOptions,
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+    expect(
+      code,
+      contains('sealed class PlatformEvent'),
+    );
+    expect(
+      code,
+      contains('data class IntEvent'),
+    );
+    expect(code, contains(': PlatformEvent'));
+    expect(
+      code,
+      contains('data class ClassEvent'),
+    );
+  });
+
+  test('empty class', () {
+    final Root root = Root(
+      apis: <Api>[],
+      classes: <Class>[
+        Class(
+          name: 'EmptyClass',
+          fields: <NamedType>[],
+        ),
+      ],
+      enums: <Enum>[],
+    );
+    final StringBuffer sink = StringBuffer();
+    const KotlinGenerator generator = KotlinGenerator();
+    const InternalKotlinOptions kotlinOptions =
+        InternalKotlinOptions(kotlinOut: '');
+    generator.generate(
+      kotlinOptions,
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+
+    expect(code, contains('class EmptyClass'));
+    expect(code, isNot(contains('data class EmptyClass')));
+  });
 }

--- a/packages/pigeon/test/swift_generator_test.dart
+++ b/packages/pigeon/test/swift_generator_test.dart
@@ -1587,4 +1587,71 @@ void main() {
         contains(
             'return PigeonError(code: "channel-error", message: "Unable to establish connection on channel: \'\\(channelName)\'.", details: "")'));
   });
+
+  test('sealed class', () {
+    final Class superClass = Class(
+      name: 'PlatformEvent',
+      isSealed: true,
+      fields: const <NamedType>[],
+    );
+    final Root root = Root(
+      apis: <Api>[],
+      classes: <Class>[
+        superClass,
+        Class(
+          name: 'IntEvent',
+          superClass: superClass,
+          superClassName: superClass.name,
+          fields: <NamedType>[
+            NamedType(
+              type: const TypeDeclaration(
+                baseName: 'int',
+                isNullable: false,
+              ),
+              name: 'value',
+            )
+          ],
+        ),
+        Class(
+          name: 'ClassEvent',
+          superClass: superClass,
+          superClassName: superClass.name,
+          fields: <NamedType>[
+            NamedType(
+              type: TypeDeclaration(
+                baseName: 'Input',
+                isNullable: true,
+                associatedClass: emptyClass,
+              ),
+              name: 'value',
+            )
+          ],
+        ),
+      ],
+      enums: <Enum>[],
+    );
+    final StringBuffer sink = StringBuffer();
+    const SwiftGenerator generator = SwiftGenerator();
+    const InternalSwiftOptions kotlinOptions =
+        InternalSwiftOptions(swiftOut: '');
+    generator.generate(
+      kotlinOptions,
+      root,
+      sink,
+      dartPackageName: DEFAULT_PACKAGE_NAME,
+    );
+    final String code = sink.toString();
+    expect(
+      code,
+      contains('protocol PlatformEvent'),
+    );
+    expect(
+      code,
+      contains('struct IntEvent: PlatformEvent'),
+    );
+    expect(
+      code,
+      contains('struct ClassEvent: PlatformEvent'),
+    );
+  });
 }


### PR DESCRIPTION
closes [160501](https://github.com/flutter/flutter/issues/160501), [162466](https://github.com/flutter/flutter/issues/162466)

- Adds support for generating empty Dart classes
- Fix generating of Kotlin empty classes (no data class usage)
- Adds tests for generators (sealed/empty class)